### PR TITLE
Fixed reading of tar.gz files

### DIFF
--- a/src/OwlCore.Storage.SharpCompress.csproj
+++ b/src/OwlCore.Storage.SharpCompress.csproj
@@ -38,7 +38,7 @@
   <PropertyGroup>
     <Author>Joshua Askharoun</Author>
     <Authors>$(Author)</Authors>
-    <Version>0.0.0</Version>
+    <Version>0.0.1</Version>
     <Product>OwlCore</Product>
     <DebugType>embedded</DebugType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -52,6 +52,10 @@
       Reading and writing GZip archives is partially supported with the same limitations as SharpCompress.
     </Description>
     <PackageReleaseNotes>
+      --- 0.0.1 ---
+      [Fixes]
+      Fixed an issue where tar.gz files weren't returning entries
+
       --- 0.0.0 ---
       [New]
       Initial release of OwlCore.Storage.SharpCompress.

--- a/src/OwlCore.Storage.SharpCompress.csproj
+++ b/src/OwlCore.Storage.SharpCompress.csproj
@@ -1,60 +1,61 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <LangVersion>latest</LangVersion>
-        <WarningsAsErrors>nullable</WarningsAsErrors>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <IncludeSymbols>true</IncludeSymbols>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
 
-        <!-- Include symbol files (*.pdb) in the built .nupkg -->
-        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    <!-- Include symbol files (*.pdb) in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <None Include="..\LICENSE">
-            <Pack>True</Pack>
-            <Link>LICENSE</Link>
-            <PackagePath></PackagePath>
-        </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <Link>LICENSE</Link>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
 
-    <ItemGroup>
-        <InternalsVisibleTo Include="OwlCore.Storage.SharpCompress.Tests" />
-        
-        <PackageReference Include="PolySharp" Version="1.13.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="SharpCompress" Version="0.33.0" />
-        <PackageReference Include="OwlCore.Storage" Version="0.8.5" />
-    </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="OwlCore.Storage.SharpCompress.Tests" />
 
-    <PropertyGroup>
-        <Author>Joshua Askharoun</Author>
-        <Authors>$(Author)</Authors>
-        <Version>0.0.0</Version>
-        <Product>OwlCore</Product>
-        <DebugType>embedded</DebugType>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <!--<PackageIcon>logo.png</PackageIcon>-->
-        <NeutralLanguage>en</NeutralLanguage>
-        <Description>
-Provides a generic archive implementation via SharpCompress for the OwlCore.Storage APIs.
+    <PackageReference Include="PolySharp" Version="1.13.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="SharpCompress" Version="0.33.0" />
+    <PackageReference Include="OwlCore.Storage" Version="0.9.2" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.6.0" />
+  </ItemGroup>
 
-Verified support for `.7z`, `.tar`, and `.zip` archives created by 7Zip and `.zip` archives by Windows File Explorer.
+  <PropertyGroup>
+    <Author>Joshua Askharoun</Author>
+    <Authors>$(Author)</Authors>
+    <Version>0.0.0</Version>
+    <Product>OwlCore</Product>
+    <DebugType>embedded</DebugType>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <!--<PackageIcon>logo.png</PackageIcon>-->
+    <NeutralLanguage>en</NeutralLanguage>
+    <Description>
+      Provides a generic archive implementation via SharpCompress for the OwlCore.Storage APIs.
 
-Reading and writing GZip archives is partially supported with the same limitations as SharpCompress.
-        </Description>
-        <PackageReleaseNotes>
---- 0.0.0 ---
-[New]
-Initial release of OwlCore.Storage.SharpCompress.
-        </PackageReleaseNotes>
-    </PropertyGroup>
+      Verified support for `.7z`, `.tar`, and `.zip` archives created by 7Zip and `.zip` archives by Windows File Explorer.
+
+      Reading and writing GZip archives is partially supported with the same limitations as SharpCompress.
+    </Description>
+    <PackageReleaseNotes>
+      --- 0.0.0 ---
+      [New]
+      Initial release of OwlCore.Storage.SharpCompress.
+    </PackageReleaseNotes>
+  </PropertyGroup>
 
 </Project>

--- a/tests/ArchiveFolderTests.cs
+++ b/tests/ArchiveFolderTests.cs
@@ -7,12 +7,6 @@ public class ZipFolderTests : CommonArchiveFolderTests
 }
 
 [TestClass]
-public class GZipFolderTests : CommonArchiveFolderTests
-{
-    protected override IWritableArchive CreateArchive() => GZipArchive.Create();
-}
-
-[TestClass]
 public class TarFolderTests : CommonArchiveFolderTests
 {
     protected override IWritableArchive CreateArchive() => TarArchive.Create();


### PR DESCRIPTION
This PR introduces a workaround for an issue where ArchiveFolder and ReadOnlyArchiveFolder weren't able to open `.tar.gz` files. 

Digging into the implementation, [`IArchiveFactory`](https://github.com/adamhathcock/sharpcompress/blob/67be0cd9d7f14e48eca1d851cb17ee6383357f1f/src/SharpCompress/Factories/GZipFactory.cs#L51C14-L51C14) doesn't automatically apply the gzip decoding stream in the same way that [`IReaderFactory`](https://github.com/adamhathcock/sharpcompress/blob/67be0cd9d7f14e48eca1d851cb17ee6383357f1f/src/SharpCompress/Factories/GZipFactory.cs#L84) does.

This PR replicates the behavior inside of ReadOnlyArchiveFactory when opening the archive.