### PR TITLE
Migrated to OwlCore.Storage 0.10.0.

### DIFF
--- a/src/OwlCore.Storage.SharpCompress.csproj
+++ b/src/OwlCore.Storage.SharpCompress.csproj
@@ -26,13 +26,13 @@
   <ItemGroup>
     <InternalsVisibleTo Include="OwlCore.Storage.SharpCompress.Tests" />
 
-    <PackageReference Include="PolySharp" Version="1.13.2">
+    <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SharpCompress" Version="0.33.0" />
-    <PackageReference Include="OwlCore.Storage" Version="0.9.2" />
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.6.0" />
+    <PackageReference Include="SharpCompress" Version="0.36.0" />
+    <PackageReference Include="OwlCore.Storage" Version="0.10.0" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.7.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/OwlCore.Storage.SharpCompress.csproj
+++ b/src/OwlCore.Storage.SharpCompress.csproj
@@ -38,7 +38,7 @@
   <PropertyGroup>
     <Author>Joshua Askharoun</Author>
     <Authors>$(Author)</Authors>
-    <Version>0.0.1</Version>
+    <Version>0.1.0</Version>
     <Product>OwlCore</Product>
     <DebugType>embedded</DebugType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -52,6 +52,13 @@
       Reading and writing GZip archives is partially supported with the same limitations as SharpCompress.
     </Description>
     <PackageReleaseNotes>
+      --- 0.1.0 ---
+      [Breaking]
+      Inherits breaking changes from OwlCore.Storage 0.10.0.
+      
+      [Fixes]
+      Contains several fixes around copy, move and create operations.
+      
       --- 0.0.1 ---
       [Fixes]
       Fixed an issue where tar.gz files weren't returning entries

--- a/tests/Disk/CommonDiskArchiveFolderTests.cs
+++ b/tests/Disk/CommonDiskArchiveFolderTests.cs
@@ -33,7 +33,7 @@ public abstract class CommonDiskArchiveFolderTests
             Assert.IsNotNull(index);
             Assert.AreEqual($"{root.Id}index", index.Id);
 
-            using var indexStream = await index.OpenStreamAsync();
+            using var indexStream = await index.OpenReadAsync();
             using StreamReader reader = new(indexStream);
             string indexText = await reader.ReadToEndAsync();
         }

--- a/tests/OwlCore.Storage.SharpCompress.Tests.csproj
+++ b/tests/OwlCore.Storage.SharpCompress.Tests.csproj
@@ -9,15 +9,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 
-		<PackageReference Include="OwlCore.Storage.CommonTests" Version="0.4.1" />
+		<PackageReference Include="OwlCore.Storage.CommonTests" Version="0.5.1" />
 
 		<ProjectReference Include="..\src\OwlCore.Storage.SharpCompress.csproj" />
 	</ItemGroup>


### PR DESCRIPTION
This PR migrates OwlCore.Storage.SharpCompress to use the latest OwlCore.Storage 0.10.0.

Updates and fixes to the storage abstraction and the CommonTests have also uncovered several inconsistencies in behavior for this implementation, which this PR also attempts to address.  