### PR TITLE
Release 0.1.3: TAR.GZ layering + TAR-first detection, length fix, flush/handle improvements, backing-stream ctor

### DIFF
--- a/src/ArchiveFolder.cs
+++ b/src/ArchiveFolder.cs
@@ -1,6 +1,7 @@
 ﻿using SharpCompress.Archives;
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Threading.Tasks;
 using System.Threading;
 using System.Linq;
@@ -17,7 +18,35 @@ public class ArchiveFolder : ReadOnlyArchiveFolder, IModifiableFolder, IFlushabl
     {
     }
 
+    /// <summary>
+    /// Initializes an <see cref="ArchiveFolder"/> bound to a source <see cref="IFile"/>.
+    /// </summary>
+    /// <remarks>
+    /// For write scenarios, persistence relies on the IFile-based open path: changes are saved to a backing stream and then
+    /// finalized when the internally-owned streams are disposed (see <see cref="FlushAsync(CancellationToken)"/>).
+    /// Ensure your <see cref="IFile"/> implementation (or hosting layer) persists the backing contents to the underlying file
+    /// when the stream returned by <see cref="IFile.OpenStreamAsync(FileAccess, CancellationToken)"/> is disposed.
+    /// <para />
+    /// If you need explicit control of the write buffer, or you expect large archives (&gt; 2 GB) that should avoid in-memory buffering
+    /// and <see cref="int.MaxValue"/>-bounded buffers, prefer <see cref="ArchiveFolder(IFile, Stream)"/>
+    /// and supply a backing stream to catch and dump writes efficiently.
+    /// </remarks>
     public ArchiveFolder(IFile sourceFile) : base(sourceFile)
+    {
+    }
+
+    /// <summary>
+    /// Initializes an <see cref="ArchiveFolder"/> bound to a source <see cref="IFile"/> with an explicit backing stream for writes.
+    /// </summary>
+    /// <param name="sourceFile">The underlying file for archive persistence.</param>
+    /// <param name="backingStream">A caller-provided buffer used to accumulate write operations prior to persistence.</param>
+    /// <remarks>
+    /// Use this overload when you plan to write to the archive. <see cref="FlushAsync(CancellationToken)"/> saves changes to
+    /// <paramref name="backingStream"/>, then disposes the internally-owned streams to release file handles and allow your host
+    /// to persist the backing contents to <paramref name="sourceFile"/>. This is recommended for large archives (&gt; 2 GB) to
+    /// avoid memory-based buffering and <see cref="int.MaxValue"/> limitations.
+    /// </remarks>
+    public ArchiveFolder(IFile sourceFile, Stream backingStream) : base(sourceFile, backingStream)
     {
     }
 
@@ -38,15 +67,15 @@ public class ArchiveFolder : ReadOnlyArchiveFolder, IModifiableFolder, IFlushabl
         var id = Id + name + ZIP_DIRECTORY_SEPARATOR;
         var key = GetKey(id);
         var subfolders = await GetSubfoldersAsync(cancellationToken);
-        
+
         // Folder doesn't already exist, simply create it
         if (!subfolders.TryGetValue(key, out var folder))
             return await AddSubfolder(key, name, cancellationToken);
-        
+
         // Folder already exists and caller doesn't want to overwrite it
         if (!overwrite)
             return folder;
-            
+
         // Folder already exists and caller wants to overwrite it,
         // so get the parent and attempt to delete the existing
         // one before creating a new one.
@@ -90,7 +119,7 @@ public class ArchiveFolder : ReadOnlyArchiveFolder, IModifiableFolder, IFlushabl
     protected async Task RemoveSubfolder(string key, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        
+
         // Remove this and all child entries from archive.
         // Force enumeration with .ToList() since we're modifying the collection.
         var archive = await OpenWritableArchiveAsync(cancellationToken);
@@ -122,24 +151,78 @@ public class ArchiveFolder : ReadOnlyArchiveFolder, IModifiableFolder, IFlushabl
     protected async Task<IWritableArchive> OpenWritableArchiveAsync(CancellationToken cancellationToken = default)
     {
         var archive = await OpenArchiveAsync(cancellationToken);
-        
+
         if (archive is not IWritableArchive writableArchive)
             throw new IOException($"Archive '{Name}' ({Id}) is not writable.");
-        
+
         return writableArchive;
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// For folders created from an <see cref="IFile"/>, this method writes changes to the backing stream using
+    /// format-appropriate options, then disposes the internally-owned streams to release file handles and trigger
+    /// persistence of the backing contents to the underlying file. Instances not created from an <see cref="IFile"/>
+    /// cannot be flushed.
+    /// </remarks>
     public async Task FlushAsync(CancellationToken cancellationToken)
     {
         if (!CanFlush())
             throw new InvalidOperationException($"Only {nameof(ArchiveFolder)}s created from files can be flushed.");
-        
+
+        // Get the already-loaded writable archive (contains all our changes in memory)
         var archive = await OpenWritableArchiveAsync(cancellationToken);
-        
-        await FlushToAsync(SourceFile!, archive, cancellationToken);
+
+        // If we don't have a composite stream (e.g. if we constructed from IArchive instead of IFile),
+        // we can't flush because we don't own the underlying file
+        if (CompositeStream == null || SourceFile == null)
+        {
+            throw new InvalidOperationException($"Cannot flush {nameof(ArchiveFolder)} that was not created from a file.");
+        }
+
+        // Save archive changes to backing stream before disposal
+        if (BackingStream != null && archive is IWritableArchive writableArchive)
+        {
+            BackingStream.Position = 0;
+            BackingStream.SetLength(0);
+            
+            var fileName = SourceFile.Name;
+            
+            // Handle layered formats (.tar.gz/.tgz) - mirror FlushToAsync logic
+            if (fileName.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase) ||
+                fileName.EndsWith(".tgz", StringComparison.OrdinalIgnoreCase))
+            {
+                // For .tar.gz, write TAR data through GZip compression directly to backing stream
+                // CRITICAL: GZipStream must be disposed to write GZIP footer properly
+                using (var gzipStream = new GZipStream(BackingStream, CompressionMode.Compress, leaveOpen: true))
+                {
+                    writableArchive.SaveTo(gzipStream, new WriterOptions(CompressionType.None));
+                    gzipStream.Flush();
+                } // GZipStream disposal writes the footer and finalizes the GZIP file
+            }
+            else
+            {
+                // Single-layer formats
+                var compressionType = archive.Type switch
+                {
+                    ArchiveType.Zip => CompressionType.Deflate,
+                    ArchiveType.Tar => CompressionType.None,
+                    _ => CompressionType.None
+                };
+                
+                writableArchive.SaveTo(BackingStream, new WriterOptions(compressionType));
+            }
+            
+            BackingStream.Flush();
+        }
+
+        // CRITICAL: Dispose existing streams to release file handles before writing
+        // This triggers our disposal delegate which flushes the backing stream to the file
+        Guard.IsNotNull(RootStream);
+        RootStream.Dispose();
+        base.Dispose();
     }
-    
+
     /// <summary>
     /// Whether changes to this <see cref="ArchiveFolder"/> can be flushed to the underlying file.
     /// </summary>
@@ -163,7 +246,7 @@ public class ArchiveFolder : ReadOnlyArchiveFolder, IModifiableFolder, IFlushabl
 
         return new ReadOnlyArchiveFolder(archive, id, name);
     }
-    
+
     /// <summary>
     /// Creates an empty archive within the <paramref name="parentFolder"/>.
     /// </summary>
@@ -172,6 +255,19 @@ public class ArchiveFolder : ReadOnlyArchiveFolder, IModifiableFolder, IFlushabl
     /// <param name="archiveType">The type of archive to create.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <returns>A task containing the new <see cref="ArchiveFolder"/>.</returns>
+    /// <remarks>
+    /// This is a convenience overload that returns an <see cref="ArchiveFolder"/> already bound to the created
+    /// <see cref="IFile"/>, enabling immediate modification and reliable <see cref="FlushAsync(CancellationToken)"/>.
+    /// <para />
+    /// Binding to the source file ensures filename-based format hints (e.g., TAR-first detection for .tar.gz/.tgz),
+    /// correct format-specific save options, and controlled stream ownership that releases file handles on flush.
+    /// <para />
+    /// Prefer this overload when you want a ready-to-use, modifiable archive with safe defaults.
+    /// <para />
+    /// Use <see cref="CreateArchiveAsync(IFile, ArchiveType, CancellationToken)"/>
+    /// when you only need an initialized archive file and intend to manage archive opening/lifecycle yourself (e.g.,
+    /// to control buffering, compression, or persistence strategy).
+    /// </remarks>
     public static async Task<ArchiveFolder> CreateArchiveAsync(IModifiableFolder parentFolder, string name,
         ArchiveType archiveType, CancellationToken cancellationToken)
     {
@@ -180,10 +276,39 @@ public class ArchiveFolder : ReadOnlyArchiveFolder, IModifiableFolder, IFlushabl
 
         await FlushToAsync(archiveFile, archive, cancellationToken);
 
-        var archiveFolder = new ArchiveFolder(archive, archiveFile.Name, archiveFile.Name);
+        // Create ArchiveFolder with the source file for proper lifecycle management
+        var archiveFolder = new ArchiveFolder(archiveFile);
         return archiveFolder;
     }
-    
+
+    /// <summary>
+    /// Creates an empty archive directly into the provided file and returns that file.
+    /// </summary>
+    /// <param name="archiveFile">The file to initialize as an archive. Existing contents will be overwritten.</param>
+    /// <param name="archiveType">The type of archive to create.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>The same <see cref="IFile"/> instance, after being initialized as an archive.</returns>
+    /// <remarks>
+    /// This overload keeps lifecycle control with the caller by returning only the <see cref="IFile"/>.
+    /// <para />
+    /// If you intend to manage the archive lifecycle yourself, open the appropriate <see cref="IArchive"/> (handling any needed
+    /// decompression and format selection, e.g., TAR after GZip for .tar.gz) and construct an <see cref="ArchiveFolder"/>
+    /// using the <see cref="ArchiveFolder(IArchive, string, string)"/> constructor. Along this path, detection, rewind/length handling,
+    /// and persistence semantics are your responsibility.
+    /// <para />
+    /// Avoid constructing directly from a raw <see cref="Stream"/> unless you also provide proper rewind/length/decompression wrappers.
+    /// <para />
+    /// Use <see cref="CreateArchiveAsync(IModifiableFolder, string, ArchiveType, CancellationToken)"/>
+    /// when you want a ready-to-use <see cref="ArchiveFolder"/> with safe defaults, detection heuristics, and flush/handle
+    /// management provided for you.
+    /// </remarks>
+    public static async Task<IFile> CreateArchiveAsync(IFile archiveFile, ArchiveType archiveType, CancellationToken cancellationToken)
+    {
+        var archive = ArchiveFactory.Create(archiveType);
+        await FlushToAsync(archiveFile, archive, cancellationToken);
+        return archiveFile;
+    }
+
     /// <summary>
     /// Writes an archive to the supplied file.
     /// </summary>
@@ -194,6 +319,35 @@ public class ArchiveFolder : ReadOnlyArchiveFolder, IModifiableFolder, IFlushabl
     {
         using var archiveFileStream = await archiveFile.OpenReadWriteAsync(cancellationToken);
         Guard.IsEqualTo(archiveFileStream.Position, 0);
-        archive.SaveTo(archiveFileStream, new WriterOptions(CompressionType.Deflate));
+
+        var fileName = archiveFile.Name;
+
+        // Handle layered formats (.tar.gz/.tgz) - stream directly to avoid memory issues
+        if (fileName.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".tgz", StringComparison.OrdinalIgnoreCase))
+        {
+            // Stream directly to GZip without using MemoryStream for large file support
+            // CRITICAL: GZipStream must be disposed to write GZIP footer properly
+            using (var gzipStream = new GZipStream(archiveFileStream, CompressionMode.Compress, leaveOpen: true))
+            {
+                archive.SaveTo(gzipStream, new WriterOptions(CompressionType.None));
+                await gzipStream.FlushAsync(cancellationToken);
+            } // GZipStream disposal writes the footer and finalizes the GZIP file
+        }
+        else
+        {
+            // Single-layer formats
+            var compressionType = archive.Type switch
+            {
+                ArchiveType.Zip => CompressionType.Deflate,
+                ArchiveType.Tar => CompressionType.None,
+                _ => CompressionType.None // Default fallback
+            };
+
+            archive.SaveTo(archiveFileStream, new WriterOptions(compressionType));
+        }
+
+        // Ensure the data is actually written to the underlying storage
+        await archiveFileStream.FlushAsync(cancellationToken);
     }
 }

--- a/src/OwlCore.Storage.SharpCompress.csproj
+++ b/src/OwlCore.Storage.SharpCompress.csproj
@@ -38,7 +38,7 @@
   <PropertyGroup>
     <Author>Joshua Askharoun</Author>
     <Authors>$(Author)</Authors>
-    <Version>0.1.2</Version>
+  <Version>0.1.3</Version>
     <Product>OwlCore</Product>
     <DebugType>embedded</DebugType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -52,6 +52,24 @@
       Reading and writing GZip archives is partially supported with the same limitations as SharpCompress.
     </Description>
     <PackageReleaseNotes>
+      --- 0.1.3 ---
+      [New]
+      Added overload constructors to open archives from an IFile with an external backing stream for tracked lifecycle and flush support.
+      Exposed stream ownership hooks to inheritors (`RootStream`, `CompositeStream`, and optional `BackingStream`).
+
+      [Improvements]
+      Layered archive handling for `.tar.gz`/`.tgz`: manual GZip decompression and TAR-first factory ordering based on filename hints to avoid Zip detection stalls.
+      Format-aware flush/save: selects `CompressionType` per format and streams directly to GZip without intermediate buffers; ensures GZip footer emission and durability.
+      Archive creation now returns an `ArchiveFolder` bound to the source file, enabling `CanFlush` and correct disposal semantics. 
+      Proactive handle management: disposes composite/root streams before persisting changes to release file locks on Windows.
+
+      [Fixes]
+      Resolved empty TAR enumeration caused by using compressed lengths after GZip; supply an estimated decompressed length to `LengthOverrideStream`.
+      Eliminated hang when probing `.tar.gz` by prioritizing TAR factory after decompression.
+
+      [Notes]
+      Validated end-to-end with OwlCore.Storage.Mcp archive mounting and writable workflows. Additive writes are supported; in-place modification of existing entries remains limited by format/library behavior.
+
       --- 0.1.2 ---
       [New]
       Added helper methods and matching `IFolder` extensions for creating and flushing archives.

--- a/src/OwlCore.Storage.SharpCompress.csproj
+++ b/src/OwlCore.Storage.SharpCompress.csproj
@@ -31,8 +31,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SharpCompress" Version="0.36.0" />
-    <PackageReference Include="OwlCore.Storage" Version="0.12.0" />
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.9.0" />
+    <PackageReference Include="OwlCore.Storage" Version="0.14.0" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.10.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/ReadOnlyArchiveFolder.cs
+++ b/src/ReadOnlyArchiveFolder.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -27,11 +26,35 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
     internal const char ZIP_DIRECTORY_SEPARATOR = '/';
 
     protected IFile? SourceFile { get; }
-    
+    protected Stream? BackingStream { get; }
+
     private readonly string _key;
     private readonly IFolder? _parent;
     private IArchive? _archive;
     private Dictionary<string, IChildFolder>? _subfolders;
+
+    // Streams we create when opening from a SourceFile (ownership stays with this folder)
+    private Stream? _rootStream;           // The original stream returned by SourceFile.OpenStreamAsync
+    private Stream? _compositeStream;      // The top-most wrapped rewindable/decompression stream actually passed to Factory.Open
+    private bool _ownsStreams;             // True when we created the streams (SourceFile ctor path)
+
+    protected Stream? RootStream 
+    { 
+        get => _rootStream; 
+        set => _rootStream = value; 
+    }
+    
+    protected Stream? CompositeStream 
+    { 
+        get => _compositeStream; 
+        set => _compositeStream = value; 
+    }
+    
+    protected bool OwnsStreams 
+    { 
+        get => _ownsStreams; 
+        set => _ownsStreams = value; 
+    }
 
     public string Id { get; }
     public string Name { get; }
@@ -46,6 +69,15 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
         : this(sourceFile.Id.Hash(), Path.GetFileNameWithoutExtension(sourceFile.Name))
     {
         SourceFile = sourceFile;
+        _ownsStreams = true;
+    }
+
+    public ReadOnlyArchiveFolder(IFile sourceFile, Stream backingStream)
+        : this(sourceFile.Id.Hash(), Path.GetFileNameWithoutExtension(sourceFile.Name))
+    {
+        SourceFile = sourceFile;
+        BackingStream = backingStream;
+        _ownsStreams = true;
     }
 
     protected ReadOnlyArchiveFolder(ReadOnlyArchiveFolder parent, string name) : this(parent._archive!, CombinePath(true, parent.Id, name), name)
@@ -195,9 +227,23 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
             if (SourceFile is null)
                 throw new InvalidOperationException("ArchiveFolder requires either an archive or file.");
 
+            // Base file stream (never wrapped yet)
+            // track ownership
             var archiveStream = await SourceFile.OpenStreamAsync(FileAccess.Read, cancellationToken);
-
-            Stream rewindableStream = new LazySeekStream(archiveStream);
+            _rootStream = archiveStream;
+            
+            Stream rewindableStream;
+            if (BackingStream != null)
+            {
+                // Use provided backing stream for writes
+                rewindableStream = new LazySeekStream(archiveStream, BackingStream);
+            }
+            else
+            {
+                // Fallback to memory-based backing stream (read-only scenario)
+                rewindableStream = new LazySeekStream(archiveStream);
+            }
+            
             rewindableStream = new LengthOverrideStream(rewindableStream, archiveStream.Length);
             rewindableStream.Position = 0;
 
@@ -205,16 +251,75 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
             {
                 rewindableStream.Position = 0;
 
+                // Decompression chain (still backed by _rootStream)
                 rewindableStream = new GZipStream(rewindableStream, CompressionMode.Decompress);
-                rewindableStream = new LengthOverrideStream(rewindableStream, archiveStream.Length);
+                
+                // Estimate decompressed length to handle extreme compression ratios
+                // 20x covers pathological cases (95% compression) while ensuring minimum TAR detection size
+                long estimatedLength = Math.Max(archiveStream.Length * 20, 1024);
+                rewindableStream = new LengthOverrideStream(rewindableStream, estimatedLength);
                 rewindableStream = new LazySeekStream(rewindableStream);
 
                 rewindableStream.Position = 0;
             }
 
+            // final stream handed to SharpCompress
+            // we will manually dispose in Dispose()
+            _compositeStream = rewindableStream;
             var options = new ReaderOptions { LeaveStreamOpen = true };
+            
+            // NOTE ON FACTORY ORDERING & LAYERED FORMATS (TAR.GZ/TGZ)
+            // -----------------------------------------------------------------------------
+            // SharpCompress exposes a set of IArchiveFactory implementations (ZipFactory, TarFactory, etc.)
+            // via Factory.Factories. The default ordering is NOT guaranteed and ZipFactory commonly
+            // appears before TarFactory. After we transparently decompress a .tar.gz stream, the resulting
+            // inner stream now contains *raw TAR bytes*, but SharpCompress has no context that we already
+            // performed a GZip decompression step externally.
+            //
+            // Consequence:
+            //  - If we naively iterate factories in default order, ZipFactory.IsArchive() is invoked on TAR data.
+            //  - Zip detection can perform multi-pass scanning and, on certain non-ZIP inputs, may block for
+            //    a long time (observed hang) while attempting to validate central directory structures that
+            //    simply do not exist in TAR.
+            //  - This produced the production hang we captured in logs: detection stopped at
+            //      "Trying factory ZipFactory" and never progressed to TarFactory.
+            //
+            // Design Implications:
+            //  - We must supply *semantic hints* derived from the original filename extension BEFORE we stripped
+            //    the compression layer. Relying purely on content sniffing after manual decompression introduces
+            //    pathological detection paths.
+            //  - We intentionally re-order the factories placing TarFactory first when the original filename
+            //    ended with .tar.gz/.tgz. This is a pragmatic mitigation that avoids modifying SharpCompress internals.
+            //  - Future layered formats (e.g., .tar.bz2, nested .zip.gz) will require extending this heuristic.
+            //
+            // Guarantees & Trade-offs:
+            //  - Safe: TarFactory.IsArchive() on non-TAR is inexpensive and returns quickly.
+            //  - Prevents: Long-running ZipFactory probes on TAR streams.
+            //  - Limitation: If user renames a non-TAR GZip file to .tar.gz incorrectly, we may mis-prioritize
+            //    TarFactory first (still falls back gracefully to others if TarFactory rejects).
+            //
+            // Maintenance Guidance:
+            //  - DO NOT remove or reorder this prioritization without re-validating against TAR.GZ remount tests.
+            //  - If adding new compression layers (BZ2/XZ), replicate extension-based ordering here.
+            //  - If SharpCompress adds a native layered archive abstraction in the future, revisit this logic.
+            // ----------------------------------------------------------------------------
 
-            foreach (var factory in Factory.Factories.OfType<IArchiveFactory>())
+            // Get all available archive factories
+            var allFactories = Factory.Factories.OfType<IArchiveFactory>().ToList();
+            
+            // For .tar.gz/.tgz files (where we've decompressed), prioritize TAR factory
+            var orderedFactories = allFactories;
+            if (SourceFile?.Name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase) == true ||
+                SourceFile?.Name.EndsWith(".tgz", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                var tarFactory = allFactories.FirstOrDefault(f => f.GetType().Name.Contains("Tar"));
+                if (tarFactory != null)
+                {
+                    orderedFactories = new[] { tarFactory }.Concat(allFactories.Where(f => f != tarFactory)).ToList();
+                }
+            }
+
+            foreach (var factory in orderedFactories)
             {
                 rewindableStream.Position = 0;
                 if (factory.IsArchive(rewindableStream, options.Password))
@@ -230,10 +335,9 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
 
         if (_archive is null)
             throw new ArgumentNullException(nameof(_archive));
-
-        
+            
         cancellationToken.ThrowIfCancellationRequested();
-
+        
         return _archive;
     }
 
@@ -301,7 +405,18 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
     /// <inheritdoc />
     public void Dispose()
     {
+        // Dispose archive first (may flush internal state)
         _archive?.Dispose();
         _archive = null;
+
+        if (_ownsStreams)
+        {
+            // Disposing the top-most composite stream (LazySeekStream/GZip/LengthOverride chain)
+            // will cascade disposal to all inner wrapped streams including the original file stream.
+            try { _compositeStream?.Dispose(); } catch { }
+        }
+
+        _compositeStream = null;
+        _rootStream = null;
     }
 }


### PR DESCRIPTION
[New]
Added overload constructors to open archives from an IFile with an external backing stream for tracked lifecycle and flush support.
Exposed stream ownership hooks to inheritors (`RootStream`, `CompositeStream`, and optional `BackingStream`).

[Improvements]
Layered archive handling for `.tar.gz`/`.tgz`: manual GZip decompression and TAR-first factory ordering based on filename hints to avoid Zip detection stalls.
Format-aware flush/save: selects `CompressionType` per format and streams directly to GZip without intermediate buffers; ensures GZip footer emission and durability.
Archive creation now returns an `ArchiveFolder` bound to the source file, enabling `CanFlush` and correct disposal semantics. 
Proactive handle management: disposes composite/root streams before persisting changes to release file locks on Windows.

[Fixes]
Resolved empty TAR enumeration caused by using compressed lengths after GZip; supply an estimated decompressed length to `LengthOverrideStream`.
Eliminated hang when probing `.tar.gz` by prioritizing TAR factory after decompression.

[Notes]
Validated end-to-end with OwlCore.Storage.Mcp archive mounting and writable workflows. Additive writes are supported; in-place modification of existing entries remains limited by format/library behavior.