### PR TITLE
Release 0.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [ main, 'release/**' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore -c Release
+
+      - name: Test
+        run: dotnet test --no-build -c Release --verbosity normal

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore -c Release
+
+      - name: Test
+        run: dotnet test --no-build -c Release --verbosity normal
+
+      - name: Pack
+        run: dotnet pack --no-build -c Release -o ./artifacts
+
+      - name: Push to NuGet
+        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/src/ArchiveEntryCreatedAtProperty.cs
+++ b/src/ArchiveEntryCreatedAtProperty.cs
@@ -9,17 +9,17 @@ namespace OwlCore.Storage.SharpCompress;
 /// Returns null when the archive format does not support this timestamp (e.g., TAR, GZip, Arc).
 /// Supported formats: Zip, Rar, 7zip, Arj.
 /// </remarks>
-public sealed class ArchiveEntryCreatedAtProperty(IStorable owner, IEntry entry)
+public sealed class ArchiveEntryCreatedAtProperty(IStorable owner, IEntry? entry)
     : SimpleStorageProperty<DateTime?>(
         id: owner.Id + "/" + nameof(ICreatedAt.CreatedAt),
         name: nameof(ICreatedAt.CreatedAt),
-        getter: () => entry.CreatedTime
+        getter: () => entry?.CreatedTime
     ), ICreatedAtProperty;
 
 /// <summary>Creation timestamp property (DateTimeOffset) for archive entries.</summary>
-public sealed class ArchiveEntryCreatedAtOffsetProperty(IStorable owner, IEntry entry)
+public sealed class ArchiveEntryCreatedAtOffsetProperty(IStorable owner, IEntry? entry)
     : SimpleStorageProperty<DateTimeOffset?>(
         id: owner.Id + "/" + nameof(ICreatedAtOffset.CreatedAtOffset),
         name: nameof(ICreatedAtOffset.CreatedAtOffset),
-        getter: () => entry.CreatedTime.HasValue ? new DateTimeOffset(entry.CreatedTime.Value) : null
+        getter: () => entry is null ? null : entry.CreatedTime.HasValue ? new DateTimeOffset(entry.CreatedTime.Value) : null
     ), ICreatedAtOffsetProperty;

--- a/src/ArchiveEntryCreatedAtProperty.cs
+++ b/src/ArchiveEntryCreatedAtProperty.cs
@@ -1,0 +1,25 @@
+using System;
+using OwlCore.Storage;
+using SharpCompress.Common;
+
+namespace OwlCore.Storage.SharpCompress;
+
+/// <summary>Creation timestamp property for archive entries.</summary>
+/// <remarks>
+/// Returns null when the archive format does not support this timestamp (e.g., TAR, GZip, Arc).
+/// Supported formats: Zip, Rar, 7zip, Arj.
+/// </remarks>
+public sealed class ArchiveEntryCreatedAtProperty(IStorable owner, IEntry entry)
+    : SimpleStorageProperty<DateTime?>(
+        id: owner.Id + "/" + nameof(ICreatedAt.CreatedAt),
+        name: nameof(ICreatedAt.CreatedAt),
+        getter: () => entry.CreatedTime
+    ), ICreatedAtProperty;
+
+/// <summary>Creation timestamp property (DateTimeOffset) for archive entries.</summary>
+public sealed class ArchiveEntryCreatedAtOffsetProperty(IStorable owner, IEntry entry)
+    : SimpleStorageProperty<DateTimeOffset?>(
+        id: owner.Id + "/" + nameof(ICreatedAtOffset.CreatedAtOffset),
+        name: nameof(ICreatedAtOffset.CreatedAtOffset),
+        getter: () => entry.CreatedTime.HasValue ? new DateTimeOffset(entry.CreatedTime.Value) : null
+    ), ICreatedAtOffsetProperty;

--- a/src/ArchiveEntryLastAccessedAtProperty.cs
+++ b/src/ArchiveEntryLastAccessedAtProperty.cs
@@ -1,0 +1,25 @@
+using System;
+using OwlCore.Storage;
+using SharpCompress.Common;
+
+namespace OwlCore.Storage.SharpCompress;
+
+/// <summary>Last accessed timestamp property for archive entries.</summary>
+/// <remarks>
+/// Returns null when the archive format does not support this timestamp (e.g., TAR, GZip, Arc).
+/// Supported formats: Zip, Rar, 7zip, Arj.
+/// </remarks>
+public sealed class ArchiveEntryLastAccessedAtProperty(IStorable owner, IEntry entry)
+    : SimpleStorageProperty<DateTime?>(
+        id: owner.Id + "/" + nameof(ILastAccessedAt.LastAccessedAt),
+        name: nameof(ILastAccessedAt.LastAccessedAt),
+        getter: () => entry.LastAccessedTime
+    ), ILastAccessedAtProperty;
+
+/// <summary>Last accessed timestamp property (DateTimeOffset) for archive entries.</summary>
+public sealed class ArchiveEntryLastAccessedAtOffsetProperty(IStorable owner, IEntry entry)
+    : SimpleStorageProperty<DateTimeOffset?>(
+        id: owner.Id + "/" + nameof(ILastAccessedAtOffset.LastAccessedAtOffset),
+        name: nameof(ILastAccessedAtOffset.LastAccessedAtOffset),
+        getter: () => entry.LastAccessedTime.HasValue ? new DateTimeOffset(entry.LastAccessedTime.Value) : null
+    ), ILastAccessedAtOffsetProperty;

--- a/src/ArchiveEntryLastAccessedAtProperty.cs
+++ b/src/ArchiveEntryLastAccessedAtProperty.cs
@@ -9,17 +9,17 @@ namespace OwlCore.Storage.SharpCompress;
 /// Returns null when the archive format does not support this timestamp (e.g., TAR, GZip, Arc).
 /// Supported formats: Zip, Rar, 7zip, Arj.
 /// </remarks>
-public sealed class ArchiveEntryLastAccessedAtProperty(IStorable owner, IEntry entry)
+public sealed class ArchiveEntryLastAccessedAtProperty(IStorable owner, IEntry? entry)
     : SimpleStorageProperty<DateTime?>(
         id: owner.Id + "/" + nameof(ILastAccessedAt.LastAccessedAt),
         name: nameof(ILastAccessedAt.LastAccessedAt),
-        getter: () => entry.LastAccessedTime
+        getter: () => entry?.LastAccessedTime
     ), ILastAccessedAtProperty;
 
 /// <summary>Last accessed timestamp property (DateTimeOffset) for archive entries.</summary>
-public sealed class ArchiveEntryLastAccessedAtOffsetProperty(IStorable owner, IEntry entry)
+public sealed class ArchiveEntryLastAccessedAtOffsetProperty(IStorable owner, IEntry? entry)
     : SimpleStorageProperty<DateTimeOffset?>(
         id: owner.Id + "/" + nameof(ILastAccessedAtOffset.LastAccessedAtOffset),
         name: nameof(ILastAccessedAtOffset.LastAccessedAtOffset),
-        getter: () => entry.LastAccessedTime.HasValue ? new DateTimeOffset(entry.LastAccessedTime.Value) : null
+        getter: () => entry is null ? null : entry.LastAccessedTime.HasValue ? new DateTimeOffset(entry.LastAccessedTime.Value) : null
     ), ILastAccessedAtOffsetProperty;

--- a/src/ArchiveEntryLastModifiedAtProperty.cs
+++ b/src/ArchiveEntryLastModifiedAtProperty.cs
@@ -1,0 +1,24 @@
+using System;
+using OwlCore.Storage;
+using SharpCompress.Common;
+
+namespace OwlCore.Storage.SharpCompress;
+
+/// <summary>Last modified timestamp property for archive entries.</summary>
+/// <remarks>
+/// Supported by most archive formats. Returns null for Arc format.
+/// </remarks>
+public sealed class ArchiveEntryLastModifiedAtProperty(IStorable owner, IEntry entry)
+    : SimpleStorageProperty<DateTime?>(
+        id: owner.Id + "/" + nameof(ILastModifiedAt.LastModifiedAt),
+        name: nameof(ILastModifiedAt.LastModifiedAt),
+        getter: () => entry.LastModifiedTime
+    ), ILastModifiedAtProperty;
+
+/// <summary>Last modified timestamp property (DateTimeOffset) for archive entries.</summary>
+public sealed class ArchiveEntryLastModifiedAtOffsetProperty(IStorable owner, IEntry entry)
+    : SimpleStorageProperty<DateTimeOffset?>(
+        id: owner.Id + "/" + nameof(ILastModifiedAtOffset.LastModifiedAtOffset),
+        name: nameof(ILastModifiedAtOffset.LastModifiedAtOffset),
+        getter: () => entry.LastModifiedTime.HasValue ? new DateTimeOffset(entry.LastModifiedTime.Value) : null
+    ), ILastModifiedAtOffsetProperty;

--- a/src/ArchiveEntryLastModifiedAtProperty.cs
+++ b/src/ArchiveEntryLastModifiedAtProperty.cs
@@ -8,17 +8,17 @@ namespace OwlCore.Storage.SharpCompress;
 /// <remarks>
 /// Supported by most archive formats. Returns null for Arc format.
 /// </remarks>
-public sealed class ArchiveEntryLastModifiedAtProperty(IStorable owner, IEntry entry)
+public sealed class ArchiveEntryLastModifiedAtProperty(IStorable owner, IEntry? entry)
     : SimpleStorageProperty<DateTime?>(
         id: owner.Id + "/" + nameof(ILastModifiedAt.LastModifiedAt),
         name: nameof(ILastModifiedAt.LastModifiedAt),
-        getter: () => entry.LastModifiedTime
+        getter: () => entry?.LastModifiedTime
     ), ILastModifiedAtProperty;
 
 /// <summary>Last modified timestamp property (DateTimeOffset) for archive entries.</summary>
-public sealed class ArchiveEntryLastModifiedAtOffsetProperty(IStorable owner, IEntry entry)
+public sealed class ArchiveEntryLastModifiedAtOffsetProperty(IStorable owner, IEntry? entry)
     : SimpleStorageProperty<DateTimeOffset?>(
         id: owner.Id + "/" + nameof(ILastModifiedAtOffset.LastModifiedAtOffset),
         name: nameof(ILastModifiedAtOffset.LastModifiedAtOffset),
-        getter: () => entry.LastModifiedTime.HasValue ? new DateTimeOffset(entry.LastModifiedTime.Value) : null
+        getter: () => entry is null ? null : entry.LastModifiedTime.HasValue ? new DateTimeOffset(entry.LastModifiedTime.Value) : null
     ), ILastModifiedAtOffsetProperty;

--- a/src/ArchiveFile.cs
+++ b/src/ArchiveFile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,20 +6,36 @@ using SharpCompress.Archives;
 
 namespace OwlCore.Storage.SharpCompress;
 
-public class ArchiveFile : IChildFile
+/// <summary>
+/// An <see cref="IFile"/> implementation backed by an archive entry.
+/// </summary>
+public class ArchiveFile : IChildFile, ICreatedAt, ILastModifiedAt, ILastAccessedAt
 {
     private readonly IArchiveEntry _entry;
     private readonly IFolder _parent;
     
+    private ArchiveEntryCreatedAtProperty? _createdAt;
+    private ArchiveEntryCreatedAtOffsetProperty? _createdAtOffset;
+    private ArchiveEntryLastModifiedAtProperty? _lastModifiedAt;
+    private ArchiveEntryLastModifiedAtOffsetProperty? _lastModifiedAtOffset;
+    private ArchiveEntryLastAccessedAtProperty? _lastAccessedAt;
+    private ArchiveEntryLastAccessedAtOffsetProperty? _lastAccessedAtOffset;
+
+    /// <inheritdoc/>
     public string Id { get; }
+    
+    /// <inheritdoc/>
     public string Name { get; }
 
+    /// <summary>
+    /// Creates a new instance of <see cref="ArchiveFile"/>.
+    /// </summary>
     public ArchiveFile(IArchiveEntry entry, ReadOnlyArchiveFolder parent)
     {
         _entry = entry;
         _parent = parent;
 
-        Name = ReadOnlyArchiveFolder.GetName(entry.Key);
+        Name = ReadOnlyArchiveFolder.GetName(entry.Key!);
         Id = parent.GetRootId() + ReadOnlyArchiveFolder.ZIP_DIRECTORY_SEPARATOR + Name;
     }
     
@@ -37,9 +53,29 @@ public class ArchiveFile : IChildFile
         Name = name;
     }
 
+    /// <inheritdoc/>
+    public ICreatedAtProperty CreatedAt => _createdAt ??= new ArchiveEntryCreatedAtProperty(this, _entry);
+
+    /// <inheritdoc/>
+    public ICreatedAtOffsetProperty CreatedAtOffset => _createdAtOffset ??= new ArchiveEntryCreatedAtOffsetProperty(this, _entry);
+
+    /// <inheritdoc/>
+    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new ArchiveEntryLastModifiedAtProperty(this, _entry);
+
+    /// <inheritdoc/>
+    public ILastModifiedAtOffsetProperty LastModifiedAtOffset => _lastModifiedAtOffset ??= new ArchiveEntryLastModifiedAtOffsetProperty(this, _entry);
+
+    /// <inheritdoc/>
+    public ILastAccessedAtProperty LastAccessedAt => _lastAccessedAt ??= new ArchiveEntryLastAccessedAtProperty(this, _entry);
+
+    /// <inheritdoc/>
+    public ILastAccessedAtOffsetProperty LastAccessedAtOffset => _lastAccessedAtOffset ??= new ArchiveEntryLastAccessedAtOffsetProperty(this, _entry);
+
+    /// <inheritdoc/>
     public Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<IFolder?>(_parent);
 
+    /// <inheritdoc/>
     public Task<Stream> OpenStreamAsync(FileAccess accessMode = FileAccess.Read, CancellationToken cancellationToken = default)
     {
         if (accessMode == 0 || (int)accessMode > 3)

--- a/src/ArchiveFolder.cs
+++ b/src/ArchiveFolder.cs
@@ -125,7 +125,7 @@ public class ArchiveFolder : ReadOnlyArchiveFolder, IModifiableFolder, IFlushabl
         var archive = await OpenWritableArchiveAsync(cancellationToken);
         var entries = archive.Entries.ToList();
         foreach (var entry in entries)
-            if (entry.Key == key || IsChild(entry.Key, key))
+            if (entry.Key != null && (entry.Key == key || IsChild(entry.Key, key)))
                 archive.RemoveEntry(entry);
 
         // Remove subfolder entry if one exists

--- a/src/OwlCore.Storage.SharpCompress.csproj
+++ b/src/OwlCore.Storage.SharpCompress.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.11.1" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.12.0" />
     <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
     <PackageReference Include="SharpCompress" Version="1.0.0" />
   </ItemGroup>

--- a/src/OwlCore.Storage.SharpCompress.csproj
+++ b/src/OwlCore.Storage.SharpCompress.csproj
@@ -70,7 +70,6 @@
 
       [Build]
       Added net10.0 target framework.
-      Converted all ProjectReferences to PackageReferences.
 
       --- 0.1.3 ---
       [New]

--- a/src/OwlCore.Storage.SharpCompress.csproj
+++ b/src/OwlCore.Storage.SharpCompress.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
@@ -26,19 +26,23 @@
   <ItemGroup>
     <InternalsVisibleTo Include="OwlCore.Storage.SharpCompress.Tests" />
 
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SharpCompress" Version="0.36.0" />
-    <PackageReference Include="OwlCore.Storage" Version="0.14.0" />
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.10.0" />
+    <PackageReference Include="PolySharp" Version="1.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.11.1" />
+    <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
+    <PackageReference Include="SharpCompress" Version="1.0.0" />
   </ItemGroup>
 
   <PropertyGroup>
     <Author>Joshua Askharoun</Author>
     <Authors>$(Author)</Authors>
-  <Version>0.1.3</Version>
+  <Version>0.2.0</Version>
     <Product>OwlCore</Product>
     <DebugType>embedded</DebugType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -52,6 +56,22 @@
       Reading and writing GZip archives is partially supported with the same limitations as SharpCompress.
     </Description>
     <PackageReleaseNotes>
+      --- 0.2.0 ---
+      [New]
+      ArchiveFile now implements ICreatedAt, ILastAccessedAt, and ILastModifiedAt.
+      Added ArchiveEntryCreatedAtProperty, ArchiveEntryLastAccessedAtProperty, and ArchiveEntryLastModifiedAtProperty — each backed by SharpCompress IArchiveEntry timestamp fields.
+
+      [Dependencies]
+      Updated OwlCore.Storage to 0.15.0.
+      Updated OwlCore.ComponentModel to 0.11.1.
+      Updated SharpCompress to 1.0.0.
+      Updated PolySharp to 1.15.0.
+      Added Microsoft.SourceLink.GitHub 10.0.103.
+
+      [Build]
+      Added net10.0 target framework.
+      Converted all ProjectReferences to PackageReferences.
+
       --- 0.1.3 ---
       [New]
       Added overload constructors to open archives from an IFile with an external backing stream for tracked lifecycle and flush support.

--- a/src/ReadOnlyArchiveFolder.cs
+++ b/src/ReadOnlyArchiveFolder.cs
@@ -83,30 +83,30 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
     /// Returns null if the archive format doesn't support this timestamp or if the folder
     /// is implicit (no explicit directory entry exists in the archive).
     /// </remarks>
-    public ICreatedAtProperty CreatedAt => _createdAt ??= new ArchiveEntryCreatedAtProperty(this, new NullEntry(_directoryEntry));
+    public ICreatedAtProperty CreatedAt => _createdAt ??= new ArchiveEntryCreatedAtProperty(this, _directoryEntry);
 
     /// <inheritdoc/>
-    public ICreatedAtOffsetProperty CreatedAtOffset => _createdAtOffset ??= new ArchiveEntryCreatedAtOffsetProperty(this, new NullEntry(_directoryEntry));
-
-    /// <inheritdoc/>
-    /// <remarks>
-    /// Returns null if the archive format doesn't support this timestamp or if the folder
-    /// is implicit (no explicit directory entry exists in the archive).
-    /// </remarks>
-    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new ArchiveEntryLastModifiedAtProperty(this, new NullEntry(_directoryEntry));
-
-    /// <inheritdoc/>
-    public ILastModifiedAtOffsetProperty LastModifiedAtOffset => _lastModifiedAtOffset ??= new ArchiveEntryLastModifiedAtOffsetProperty(this, new NullEntry(_directoryEntry));
+    public ICreatedAtOffsetProperty CreatedAtOffset => _createdAtOffset ??= new ArchiveEntryCreatedAtOffsetProperty(this, _directoryEntry);
 
     /// <inheritdoc/>
     /// <remarks>
     /// Returns null if the archive format doesn't support this timestamp or if the folder
     /// is implicit (no explicit directory entry exists in the archive).
     /// </remarks>
-    public ILastAccessedAtProperty LastAccessedAt => _lastAccessedAt ??= new ArchiveEntryLastAccessedAtProperty(this, new NullEntry(_directoryEntry));
+    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new ArchiveEntryLastModifiedAtProperty(this, _directoryEntry);
 
     /// <inheritdoc/>
-    public ILastAccessedAtOffsetProperty LastAccessedAtOffset => _lastAccessedAtOffset ??= new ArchiveEntryLastAccessedAtOffsetProperty(this, new NullEntry(_directoryEntry));
+    public ILastModifiedAtOffsetProperty LastModifiedAtOffset => _lastModifiedAtOffset ??= new ArchiveEntryLastModifiedAtOffsetProperty(this, _directoryEntry);
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Returns null if the archive format doesn't support this timestamp or if the folder
+    /// is implicit (no explicit directory entry exists in the archive).
+    /// </remarks>
+    public ILastAccessedAtProperty LastAccessedAt => _lastAccessedAt ??= new ArchiveEntryLastAccessedAtProperty(this, _directoryEntry);
+
+    /// <inheritdoc/>
+    public ILastAccessedAtOffsetProperty LastAccessedAtOffset => _lastAccessedAtOffset ??= new ArchiveEntryLastAccessedAtOffsetProperty(this, _directoryEntry);
 
     public ReadOnlyArchiveFolder(IArchive archive, string id, string name) : this(id, name)
     {
@@ -476,35 +476,4 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
         _compositeStream = null;
         _rootStream = null;
     }
-    
-    /// <summary>
-    /// A wrapper that returns null for all timestamps when the underlying entry is null.
-    /// Used for folders that don't have an explicit directory entry in the archive.
-    /// </summary>
-    private sealed class NullEntry : IEntry
-    {
-        private readonly IEntry? _inner;
-        
-        public NullEntry(IEntry? inner) => _inner = inner;
-        
-        public string Key => _inner?.Key ?? string.Empty;
-        public long Size => _inner?.Size ?? 0;
-        public long CompressedSize => _inner?.CompressedSize ?? 0;
-        public CompressionType CompressionType => _inner?.CompressionType ?? CompressionType.None;
-        public DateTime? LastModifiedTime => _inner?.LastModifiedTime;
-        public DateTime? CreatedTime => _inner?.CreatedTime;
-        public DateTime? LastAccessedTime => _inner?.LastAccessedTime;
-        public DateTime? ArchivedTime => _inner?.ArchivedTime;
-        public long Crc => _inner?.Crc ?? 0;
-        public bool IsDirectory => _inner?.IsDirectory ?? true;
-        public bool IsEncrypted => _inner?.IsEncrypted ?? false;
-        public bool IsSplitAfter => _inner?.IsSplitAfter ?? false;
-        public int? Attrib => _inner?.Attrib;
-        public string? LinkTarget => _inner?.LinkTarget;
-        public bool IsSolid => _inner?.IsSolid ?? false;
-        public int VolumeIndexFirst => _inner?.VolumeIndexFirst ?? 0;
-        public int VolumeIndexLast => _inner?.VolumeIndexLast ?? 0;
-    }
 }
-
-

--- a/src/ReadOnlyArchiveFolder.cs
+++ b/src/ReadOnlyArchiveFolder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using OwlCore.ComponentModel;
 using SharpCompress.Archives;
 using SharpCompress.Archives.GZip;
+using SharpCompress.Common;
 using SharpCompress.Compressors;
 using SharpCompress.Compressors.Deflate;
 using SharpCompress.Factories;
@@ -16,7 +17,10 @@ using SharpCompress.Readers;
 
 namespace OwlCore.Storage.SharpCompress;
 
-public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstByName, IGetItemRecursive, IDisposable
+/// <summary>
+/// A read-only folder implementation backed by an archive.
+/// </summary>
+public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstByName, IGetItemRecursive, ICreatedAt, ILastModifiedAt, ILastAccessedAt, IDisposable
 {
     /// <summary>
     /// The directory separator as defined by the ZIP standard.
@@ -32,11 +36,26 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
     private readonly IFolder? _parent;
     private IArchive? _archive;
     private Dictionary<string, IChildFolder>? _subfolders;
+    
+    /// <summary>
+    /// The directory entry backing this folder, if one exists.
+    /// Some archive formats have explicit directory entries with timestamps,
+    /// others only have implicit directories inferred from file paths.
+    /// </summary>
+    private IEntry? _directoryEntry;
 
     // Streams we create when opening from a SourceFile (ownership stays with this folder)
     private Stream? _rootStream;           // The original stream returned by SourceFile.OpenStreamAsync
     private Stream? _compositeStream;      // The top-most wrapped rewindable/decompression stream actually passed to Factory.Open
     private bool _ownsStreams;             // True when we created the streams (SourceFile ctor path)
+    
+    // Timestamp properties (lazily initialized)
+    private ArchiveEntryCreatedAtProperty? _createdAt;
+    private ArchiveEntryCreatedAtOffsetProperty? _createdAtOffset;
+    private ArchiveEntryLastModifiedAtProperty? _lastModifiedAt;
+    private ArchiveEntryLastModifiedAtOffsetProperty? _lastModifiedAtOffset;
+    private ArchiveEntryLastAccessedAtProperty? _lastAccessedAt;
+    private ArchiveEntryLastAccessedAtOffsetProperty? _lastAccessedAtOffset;
 
     protected Stream? RootStream 
     { 
@@ -58,6 +77,36 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
 
     public string Id { get; }
     public string Name { get; }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Returns null if the archive format doesn't support this timestamp or if the folder
+    /// is implicit (no explicit directory entry exists in the archive).
+    /// </remarks>
+    public ICreatedAtProperty CreatedAt => _createdAt ??= new ArchiveEntryCreatedAtProperty(this, new NullEntry(_directoryEntry));
+
+    /// <inheritdoc/>
+    public ICreatedAtOffsetProperty CreatedAtOffset => _createdAtOffset ??= new ArchiveEntryCreatedAtOffsetProperty(this, new NullEntry(_directoryEntry));
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Returns null if the archive format doesn't support this timestamp or if the folder
+    /// is implicit (no explicit directory entry exists in the archive).
+    /// </remarks>
+    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new ArchiveEntryLastModifiedAtProperty(this, new NullEntry(_directoryEntry));
+
+    /// <inheritdoc/>
+    public ILastModifiedAtOffsetProperty LastModifiedAtOffset => _lastModifiedAtOffset ??= new ArchiveEntryLastModifiedAtOffsetProperty(this, new NullEntry(_directoryEntry));
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Returns null if the archive format doesn't support this timestamp or if the folder
+    /// is implicit (no explicit directory entry exists in the archive).
+    /// </remarks>
+    public ILastAccessedAtProperty LastAccessedAt => _lastAccessedAt ??= new ArchiveEntryLastAccessedAtProperty(this, new NullEntry(_directoryEntry));
+
+    /// <inheritdoc/>
+    public ILastAccessedAtOffsetProperty LastAccessedAtOffset => _lastAccessedAtOffset ??= new ArchiveEntryLastAccessedAtOffsetProperty(this, new NullEntry(_directoryEntry));
 
     public ReadOnlyArchiveFolder(IArchive archive, string id, string name) : this(id, name)
     {
@@ -83,6 +132,14 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
     protected ReadOnlyArchiveFolder(ReadOnlyArchiveFolder parent, string name) : this(parent._archive!, CombinePath(true, parent.Id, name), name)
     {
         _parent = parent;
+        
+        // Try to find the directory entry for this subfolder
+        // The key for this folder (e.g., "subfolder/") may have an explicit entry
+        if (parent._archive != null)
+        {
+            _directoryEntry = parent._archive.Entries.FirstOrDefault(e => 
+                e.Key == _key || e.Key == _key.TrimEnd(ZIP_DIRECTORY_SEPARATOR));
+        }
     }
 
     protected ReadOnlyArchiveFolder(string id, string name)
@@ -118,7 +175,7 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
             foreach (var entry in archive.Entries)
             {
                 // Only look at children of this current folder
-                if (!IsChild(entry.Key, _key) || IsDirectory(entry))
+                if (entry.Key is null || !IsChild(entry.Key, _key) || IsDirectory(entry))
                     continue;
 
                 cancellationToken.ThrowIfCancellationRequested();
@@ -198,7 +255,7 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!entry.Key.StartsWith(_key))
+            if (entry.Key is null || !entry.Key.StartsWith(_key))
                 continue;
 
             var relativeKey = entry.Key.Remove(0, _key.Length);
@@ -343,7 +400,7 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
 
     protected static string GetKey(string id) => id[(id.IndexOf(ZIP_DIRECTORY_SEPARATOR) + 1)..];
 
-    protected static bool IsDirectory(IArchiveEntry entry) => entry.IsDirectory || entry.Key[^1] == ZIP_DIRECTORY_SEPARATOR;
+    protected static bool IsDirectory(IArchiveEntry entry) => entry.IsDirectory || (entry.Key is not null && entry.Key[^1] == ZIP_DIRECTORY_SEPARATOR);
 
     internal static string GetName(string id)
     {
@@ -419,4 +476,35 @@ public class ReadOnlyArchiveFolder : IFolder, IChildFolder, IGetItem, IGetFirstB
         _compositeStream = null;
         _rootStream = null;
     }
+    
+    /// <summary>
+    /// A wrapper that returns null for all timestamps when the underlying entry is null.
+    /// Used for folders that don't have an explicit directory entry in the archive.
+    /// </summary>
+    private sealed class NullEntry : IEntry
+    {
+        private readonly IEntry? _inner;
+        
+        public NullEntry(IEntry? inner) => _inner = inner;
+        
+        public string Key => _inner?.Key ?? string.Empty;
+        public long Size => _inner?.Size ?? 0;
+        public long CompressedSize => _inner?.CompressedSize ?? 0;
+        public CompressionType CompressionType => _inner?.CompressionType ?? CompressionType.None;
+        public DateTime? LastModifiedTime => _inner?.LastModifiedTime;
+        public DateTime? CreatedTime => _inner?.CreatedTime;
+        public DateTime? LastAccessedTime => _inner?.LastAccessedTime;
+        public DateTime? ArchivedTime => _inner?.ArchivedTime;
+        public long Crc => _inner?.Crc ?? 0;
+        public bool IsDirectory => _inner?.IsDirectory ?? true;
+        public bool IsEncrypted => _inner?.IsEncrypted ?? false;
+        public bool IsSplitAfter => _inner?.IsSplitAfter ?? false;
+        public int? Attrib => _inner?.Attrib;
+        public string? LinkTarget => _inner?.LinkTarget;
+        public bool IsSolid => _inner?.IsSolid ?? false;
+        public int VolumeIndexFirst => _inner?.VolumeIndexFirst ?? 0;
+        public int VolumeIndexLast => _inner?.VolumeIndexLast ?? 0;
+    }
 }
+
+

--- a/tests/CommonArchiveFileTests.cs
+++ b/tests/CommonArchiveFileTests.cs
@@ -1,8 +1,27 @@
-﻿namespace OwlCore.Storage.SharpCompress.Tests;
+using OwlCore.Storage.CommonTests;
+
+namespace OwlCore.Storage.SharpCompress.Tests;
 
 public abstract class CommonArchiveFileTests : CommonIFileTests
 {
     protected abstract IWritableArchive CreateArchive();
+
+    /// <summary>
+    /// Archive format timestamps may or may not be available depending on the format.
+    /// TAR/GZip/Arc don't support CreatedAt. Zip/Rar/7zip/Arj do.
+    /// </summary>
+    public override PropertyValueAvailability CreatedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <summary>
+    /// Most archive formats support LastModifiedAt, but Arc doesn't.
+    /// </summary>
+    public override PropertyValueAvailability LastModifiedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <summary>
+    /// Archive format timestamps may or may not be available depending on the format.
+    /// TAR/GZip/Arc don't support LastAccessedAt. Zip/Rar/7zip/Arj do.
+    /// </summary>
+    public override PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Maybe;
 
     public override Task<IFile> CreateFileAsync()
     {
@@ -20,6 +39,30 @@ public abstract class CommonArchiveFileTests : CommonIFileTests
 
         return Task.FromResult<IFile>(file);
     }
+
+    /// <summary>
+    /// Creates a file with a specific LastModifiedAt timestamp.
+    /// Archive formats support setting modification time at entry creation.
+    /// </summary>
+    public override Task<IFile?> CreateFileWithLastModifiedAtAsync(DateTime lastModifiedAt)
+    {
+        var archive = CreateArchive();
+        
+        // SharpCompress AddEntry signature: AddEntry(string key, Stream source, bool closeStream, long size, DateTime? modified)
+        // We use the overload that accepts a modification time
+        var content = new MemoryStream(GenerateRandomData(256_000));
+        var entry = archive.AddEntry($"{Guid.NewGuid()}", content, false, content.Length, lastModifiedAt);
+
+        var folder = new ReadOnlyArchiveFolder(archive, $"root_{Guid.NewGuid()}", "root");
+        var file = new ArchiveFile(entry, folder);
+
+        return Task.FromResult<IFile?>(file);
+    }
+
+    // CreatedAt and LastAccessedAt cannot be set via SharpCompress AddEntry API.
+    // Those timestamps come from reading existing archives that have extended timestamp data.
+    public override Task<IFile?> CreateFileWithCreatedAtAsync(DateTime createdAt) => Task.FromResult<IFile?>(null);
+    public override Task<IFile?> CreateFileWithLastAccessedAtAsync(DateTime lastAccessedAt) => Task.FromResult<IFile?>(null);
 
     internal static byte[] GenerateRandomData(int length)
     {

--- a/tests/CommonArchiveFolderTests.cs
+++ b/tests/CommonArchiveFolderTests.cs
@@ -1,10 +1,30 @@
-﻿namespace OwlCore.Storage.SharpCompress.Tests;
+﻿using OwlCore.Storage.CommonTests;
+
+namespace OwlCore.Storage.SharpCompress.Tests;
 
 public abstract class CommonArchiveFolderTests : CommonIModifiableFolderTests
 {
     // Required for base class to perform common tests.
 
     protected abstract IWritableArchive CreateArchive();
+
+    /// <summary>
+    /// Archive folder timestamps may be null for implicit folders (no explicit directory entry)
+    /// or for formats that don't support this timestamp.
+    /// </summary>
+    public override PropertyValueAvailability CreatedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <summary>
+    /// Archive folder timestamps may be null for implicit folders (no explicit directory entry)
+    /// or for formats that don't support this timestamp.
+    /// </summary>
+    public override PropertyValueAvailability LastModifiedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <summary>
+    /// Archive folder timestamps may be null for implicit folders (no explicit directory entry)
+    /// or for formats that don't support this timestamp.
+    /// </summary>
+    public override PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Maybe;
 
     public override async Task<IModifiableFolder> CreateModifiableFolderAsync()
     {
@@ -28,6 +48,13 @@ public abstract class CommonArchiveFolderTests : CommonIModifiableFolderTests
 
         return folder;
     }
+
+    // Archives don't support setting folder timestamps at creation
+    public override Task<IFolder?> CreateFolderWithCreatedAtAsync(DateTime createdAt) => Task.FromResult<IFolder?>(null);
+    public override Task<IFolder?> CreateFolderWithLastModifiedAtAsync(DateTime lastModifiedAt) => Task.FromResult<IFolder?>(null);
+    public override Task<IFolder?> CreateFolderWithLastAccessedAtAsync(DateTime lastAccessedAt) => Task.FromResult<IFolder?>(null);
+    public override Task<IFile?> CreateFileInFolderWithLastModifiedAtAsync(IModifiableFolder folder, DateTime lastModifiedAt) => Task.FromResult<IFile?>(null);
+    public override Task<CommonIModifiableFolderTests.CreateFileInFolderWithTimestampsResult?> CreateFileInFolderWithTimestampsAsync(IModifiableFolder folder, DateTime? createdAt, DateTime? lastModifiedAt, DateTime? lastAccessedAt) => Task.FromResult<CommonIModifiableFolderTests.CreateFileInFolderWithTimestampsResult?>(null);
 
     public async Task<IModifiableFolder> CreateModifiableFolderWithNestedItems()
     {

--- a/tests/OwlCore.Storage.SharpCompress.Tests.csproj
+++ b/tests/OwlCore.Storage.SharpCompress.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -9,15 +9,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+		<PackageReference Include="coverlet.collector" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-
-		<PackageReference Include="OwlCore.Storage.CommonTests" Version="0.5.1" />
+		<PackageReference Include="OwlCore.Storage" Version="0.15.0" />
+		<PackageReference Include="OwlCore.Storage.CommonTests" Version="0.6.2" />
 
 		<ProjectReference Include="..\src\OwlCore.Storage.SharpCompress.csproj" />
 	</ItemGroup>


### PR DESCRIPTION
This release highlights the implementation of date properties and the addition of net10.0 as an explicit TargetFramework. 

---

#### Full release notes:

New:
- ArchiveFile now implements `ICreatedAt`, `ILastAccessedAt`, and `ILastModifiedAt` from OwlCore.Storage 0.15.0.
- Added `ArchiveEntryCreatedAtProperty`, `ArchiveEntryLastAccessedAtProperty`, and `ArchiveEntryLastModifiedAtProperty` - each backed by SharpCompress `IArchiveEntry` timestamp fields.

Dependencies:
- Updated OwlCore.Storage to 0.15.0.
- Updated OwlCore.ComponentModel to 0.11.1.
- Updated SharpCompress to 1.0.0.
- Updated PolySharp to 1.15.0.
- Added Microsoft.SourceLink.GitHub 10.0.103.

Build:
- Added net10.0 target framework.